### PR TITLE
replaced `question` by `query` to improve small LMs zero-shooting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "wolframalpha-mcp-server": "build/index.js"
       },
       "devDependencies": {
-        "@types/jest": "^29.5.14",
-        "@types/node": "^20.11.24",
+        "@types/jest": "29.5.14",
+        "@types/node": "20.17.19",
         "dotenv": "^16.4.7",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "axios": "^1.7.9"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.14",
-    "@types/node": "^20.11.24",
+    "@types/jest": "29.5.14",
+    "@types/node": "20.17.19",
     "dotenv": "^16.4.7",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
   McpError,
 } from "@modelcontextprotocol/sdk/types.js";
 import { tools } from "./tools/index.js";
-import { Tool, ToolResponse, QuestionArgs, EmptyArgs } from "./types/index.js";
+import { Tool, ToolResponse, QueryArgs, EmptyArgs } from "./types/index.js";
 
 // Initialize MCP server
 const server = new Server(
@@ -80,11 +80,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
     if (tool.name === 'validate_key') {
       response = await (tool as Tool<EmptyArgs>).handler({});
     } else {
-      // Convert args to QuestionArgs, ensuring question property exists
-      const questionArgs = {
-        question: (args as any).question
-      } as QuestionArgs;
-      response = await (tool as Tool<QuestionArgs>).handler(questionArgs);
+      // Convert args to QueryArgs, ensuring query property exists
+      const queryArgs = {
+        query: (args as any).query
+      } as QueryArgs;
+      response = await (tool as Tool<QueryArgs>).handler(queryArgs);
     }
 
     // Add metadata if provided

--- a/src/services/__tests__/wolfram-llm.test.ts
+++ b/src/services/__tests__/wolfram-llm.test.ts
@@ -121,7 +121,7 @@ describe('WolframLLMService Integration Tests', () => {
       const result = await service.query('xyzabc123 qwerty asdfgh');
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Input cannot be interpreted. Try rephrasing your question.');
+      expect(result.error).toBe('Input cannot be interpreted. Try rephrasing your query.');
     });
 
     it('should provide detailed astronomical data about Mars', async () => {

--- a/src/services/wolfram-llm.ts
+++ b/src/services/wolfram-llm.ts
@@ -145,7 +145,7 @@ export class WolframLLMService {
   }
 
   /**
-   * Query WolframAlpha's LLM API with a natural language question
+   * Query WolframAlpha's LLM API with a natural language query
    * Returns structured data optimized for LLM consumption
    */
   async query(input: string): Promise<LLMQueryResult> {
@@ -194,7 +194,7 @@ export class WolframLLMService {
       if (axios.isAxiosError(error) && error.response?.status === 501) {
         return {
           success: false,
-          error: 'Input cannot be interpreted. Try rephrasing your question.',
+          error: 'Input cannot be interpreted. Try rephrasing your query.',
           rawResponse
         };
       }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,5 @@
 import { WolframLLMService } from '../services/wolfram-llm.js';
-import { QuestionArgs, EmptyArgs, ToolResponse } from '../types/index.js';
+import { QueryArgs, EmptyArgs, ToolResponse } from '../types/index.js';
 
 // Initialize service
 const wolframLLMService = new WolframLLMService({
@@ -9,19 +9,19 @@ const wolframLLMService = new WolframLLMService({
 export const tools = [
   {
     name: "ask_llm",
-    description: "Ask WolframAlpha a question and get LLM-optimized structured response with multiple formats",
+    description: "Ask WolframAlpha a query and get LLM-optimized structured response with multiple formats",
     inputSchema: {
       type: "object",
       properties: {
-        question: {
+        query: {
           type: "string",
-          description: "The question to ask WolframAlpha"
+          description: "The query to ask WolframAlpha"
         }
       },
-      required: ["question"]
+      required: ["query"]
     },
-    handler: async (args: QuestionArgs): Promise<ToolResponse> => {
-      const response = await wolframLLMService.query(args.question);
+    handler: async (args: QueryArgs): Promise<ToolResponse> => {
+      const response = await wolframLLMService.query(args.query);
       if (!response.success || !response.result) {
         throw new Error(response.error || 'Failed to get LLM response from WolframAlpha');
       }
@@ -55,15 +55,15 @@ export const tools = [
     inputSchema: {
       type: "object",
       properties: {
-        question: {
+        query: {
           type: "string",
-          description: "The question to ask WolframAlpha"
+          description: "The query to ask WolframAlpha"
         }
       },
-      required: ["question"]
+      required: ["query"]
     },
-    handler: async (args: QuestionArgs): Promise<ToolResponse> => {
-      const response = await wolframLLMService.getSimplifiedAnswer(args.question);
+    handler: async (args: QueryArgs): Promise<ToolResponse> => {
+      const response = await wolframLLMService.getSimplifiedAnswer(args.query);
       if (!response.success || !response.result) {
         throw new Error(response.error || 'Failed to get simplified answer from WolframAlpha');
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,13 +8,13 @@ export interface ToolResponse {
   [key: string]: any; // Allow additional properties for MCP SDK compatibility
 }
 
-export interface QuestionArgs {
-  question: string;
+export interface QueryArgs {
+  query: string;
 }
 
 export interface EmptyArgs {}
 
-export type ToolArgs = QuestionArgs | EmptyArgs;
+export type ToolArgs = QueryArgs | EmptyArgs;
 
 export interface Tool<T = any> {
   name: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": false,
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "5.0",
+    "typeRoots": ["node_modules/@types"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "build"]


### PR DESCRIPTION
For example [Arcee's Blitz model](https://huggingface.co/arcee-ai/Arcee-Blitz), is always requiring several trials before making it, I guess because `question` is most common when making an API request than `query` when related to WolframAlpha!
It won't follow the correct format even when specifying that the format is "query" like this:

```
    "wolframalpha-llm-mcp": {
      "command": "node",
      "args": [
        "/home/user/cline_mcp_servers/wolframalpha-llm-mcp/build/index.js"
      ],
      "tools": [
        {
          "name": "ask_llm",
          "inputs": [
            {
              "name": "query",
              "type": "string"
            }
          ]
        },
        {
          "name": "get_simpler_answer",
          "inputs": [
            {
              "name": "query",
              "type": "string"
            }
          ]
        }
      ],
      "env": {
        "WOLFRAM_LLM_APP_ID": "XXXXX-XXXX"
      },
      "disabled": false,
      "autoApprove": [
        "ask_llm",
        "validate_key"
      ]
    }
```
I didn't try out with other small models for now, but that solved it for this Mistral Small 24b based model.
That said, I'm sorry I didn't plan to make this PR that early, I was tired and managed to miss a click and make it from VSC, don't ask how.
So as I didn't want to make a mess deleting it to maybe make a new one later, so I decided to complete it.

Feel free to do whatever with it, as again, that was unintentional in the first place.

I hope that you at least had some laugh reading this...

Anyway, thanks for your tool, working like a charm ;)