### PR TITLE
fix: dotenv needed for prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "0.6.0",
+    "dotenv": "^16.4.7",
     "axios": "^1.7.9"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "^20.11.24",
-    "dotenv": "^16.4.7",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.3.3"


### PR DESCRIPTION
index.ts uses dotenv so is not just a dev dependency.  